### PR TITLE
Add horizontal margin to "white box" on mobile

### DIFF
--- a/themes/gceurope/static/css/main.css
+++ b/themes/gceurope/static/css/main.css
@@ -353,6 +353,9 @@ a {
     .demands {
         box-shadow: none;
     }
+    .white-box {
+        margin: 0 1rem;
+    }
     .who {
         display: block;
     }


### PR DESCRIPTION
The rounded corners of the "white boxes" felt a bit out of place on mobile. Introducing some horizontal margin makes the boxes feel as actual boxes and makes the mobile experience more similar to the desktop experience.

Changes
![image](https://user-images.githubusercontent.com/15815208/64488732-74795680-d24b-11e9-8e78-282892d3d010.png)
to
![image](https://user-images.githubusercontent.com/15815208/64488733-7ba06480-d24b-11e9-9d22-36c7ea18de3b.png).